### PR TITLE
Fix #1202: remove trailing comma from function arguments list

### DIFF
--- a/blib2to3/pgen2/driver.py
+++ b/blib2to3/pgen2/driver.py
@@ -128,7 +128,7 @@ class Driver(object):
         return self.parse_stream_raw(stream, debug)
 
     def parse_file(
-        self, filename: Path, encoding: Optional[Text] = None, debug: bool = False,
+        self, filename: Path, encoding: Optional[Text] = None, debug: bool = False
     ) -> NL:
         """Parse a file and return the syntax tree."""
         with io.open(filename, "r", encoding=encoding) as stream:

--- a/tests/data/collections.py
+++ b/tests/data/collections.py
@@ -154,8 +154,8 @@ if True:
         InstanceIds=[instance.id], WaiterConfig={"Delay": 5,}
     )
     ec2client.get_waiter("instance_stopped").wait(
-        InstanceIds=[instance.id], WaiterConfig={"Delay": 5,},
+        InstanceIds=[instance.id], WaiterConfig={"Delay": 5,}
     )
     ec2client.get_waiter("instance_stopped").wait(
-        InstanceIds=[instance.id], WaiterConfig={"Delay": 5,},
+        InstanceIds=[instance.id], WaiterConfig={"Delay": 5,}
     )

--- a/tests/data/comments7.py
+++ b/tests/data/comments7.py
@@ -93,7 +93,7 @@ result = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 
 
 def func():
-    c = call(0.0123, 0.0456, 0.0789, 0.0123, 0.0789, a[-1],)  # type: ignore
+    c = call(0.0123, 0.0456, 0.0789, 0.0123, 0.0789, a[-1])  # type: ignore
 
     # The type: ignore exception only applies to line length, not
     # other types of formatting.

--- a/tests/data/expression.diff
+++ b/tests/data/expression.diff
@@ -212,7 +212,7 @@
 +    .filter(
 +        models.Customer.account_id == account_id, models.Customer.email == email_address
 +    )
-+    .order_by(models.Customer.id.asc(),)
++    .order_by(models.Customer.id.asc())
 +    .all()
 +)
  Ø = set()

--- a/tests/data/expression.py
+++ b/tests/data/expression.py
@@ -459,7 +459,7 @@ result = (
     .filter(
         models.Customer.account_id == account_id, models.Customer.email == email_address
     )
-    .order_by(models.Customer.id.asc(),)
+    .order_by(models.Customer.id.asc())
     .all()
 )
 Ø = set()

--- a/tests/data/function.py
+++ b/tests/data/function.py
@@ -230,7 +230,7 @@ def trailing_comma():
     }
 
 
-def f(a, **kwargs,) -> A:
+def f(a, **kwargs) -> A:
     return (
         yield from A(
             very_long_argument_name1=very_long_value_for_the_argument,

--- a/tests/data/function2.py
+++ b/tests/data/function2.py
@@ -25,7 +25,7 @@ def h():
 
 # output
 
-def f(a, **kwargs,) -> A:
+def f(a, **kwargs) -> A:
     with cache_dir():
         if something:
             result = CliRunner().invoke(

--- a/tests/data/function_trailing_comma.py
+++ b/tests/data/function_trailing_comma.py
@@ -9,13 +9,21 @@ def xxxxxxxxxxxxxxxxxxxxxxxxxxxx() -> Set[
 ]:
     pass
 
+def _gopass_process() -> Popen:
+    """Spawn a Gopass process"""
+    return Popen(
+        ['gopass', 'jsonapi', 'listen'],
+        stdout=PIPE,
+        stdin=PIPE,
+    )
+
 # output
 
-def f(a,):
+def f(a):
     ...
 
 
-def f(a: int = 1,):
+def f(a: int = 1):
     ...
 
 
@@ -23,3 +31,8 @@ def xxxxxxxxxxxxxxxxxxxxxxxxxxxx() -> Set[
     "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 ]:
     pass
+
+
+def _gopass_process() -> Popen:
+    """Spawn a Gopass process"""
+    return Popen(["gopass", "jsonapi", "listen"], stdout=PIPE, stdin=PIPE)


### PR DESCRIPTION
The commit that changed the comma removing logic: 9854d4b375ef84d651892785165a6c7b0e9f391b
What I did: looked at the history of the function and added back the pre-existing logic, adapting it a little bit to target specifically the function parameters list.
See https://github.com/psf/black/blob/master/CONTRIBUTING.md for instructions on how to contribute and run the tests locally.